### PR TITLE
feat: Allow supplying templates from files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- [\#2](https://github.com/gunnyworks/gunny/pull/2) Allow the user to supply
+  templates from files with the `--template-file` CLI argument.
+
 ## v0.1.3
 
 _Aug 31st, 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## v0.1.3
 
 _Aug 31st, 2025_

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ go install github.com/gunnyworks/gunny/cmd/gunny@latest
 
 ```bash
 # Supply template and data via CLI arguments
-gunny -t 'Hello {{name}}!' -v name=Michael
+gunny -t 'Hello {{name}}!' -d name=Michael
 # Hello Michael!
 
 # Supply template via CLI argument, but pipe data in in JSON format
@@ -45,6 +45,17 @@ echo '{"name": "Gary"}' | gunny -t 'Hello {{name}}!'
 # Pipe data in in YAML format
 echo 'name: Sarah' | gunny -t 'Hello {{name}}!' --stdin-format yaml
 # Hello Sarah!
+```
+
+### File-based templates
+
+```bash
+echo 'Hello {{name}}!' > ./hello.mustache
+gunny --template-file ./hello.mustache -d name=Michael
+# Hello Michael!
+
+echo '{"name": "Gary"}' | gunny --template-file ./hello.mustache
+# Hello Gary!
 ```
 
 ## Versioning

--- a/cmd/gunny/root.go
+++ b/cmd/gunny/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -17,6 +18,7 @@ func newRootCmd(version string, commit string) *cobra.Command {
 	showVersion := false
 	verbose := false
 	templateContent := ""
+	templateFilePath := ""
 	namedDataValues := []string{}
 	stdinDataFormatString := string(gunny.DataFormatJSON)
 
@@ -34,6 +36,8 @@ func newRootCmd(version string, commit string) *cobra.Command {
 					TimeFormat: time.RFC3339,
 				}),
 			))
+
+			// Handle showing of version and exiting
 			if showVersion {
 				if len(commit) > 0 {
 					fmt.Printf("%s-%s\n", version, commit)
@@ -42,14 +46,46 @@ func newRootCmd(version string, commit string) *cobra.Command {
 				}
 				os.Exit(0)
 			}
+
+			// Validate template configuration
+			if len(templateFilePath) == 0 && len(templateContent) == 0 {
+				slog.Error("Must supply a template, either via CLI argument or from a file")
+				os.Exit(1)
+			}
+			if len(templateFilePath) > 0 && len(templateContent) > 0 {
+				slog.Error("Can only supply one template, either via CLI argument or from a file (not both)")
+				os.Exit(1)
+			}
+			var templateReader io.Reader
+			var templateFile *os.File
+			if len(templateContent) > 0 {
+				templateReader = strings.NewReader(templateContent)
+			} else {
+				var err error
+				templateFile, err = os.Open(templateFilePath)
+				if err != nil {
+					slog.Error("Failed to open template file", "path", templateFilePath, "error", err)
+					os.Exit(1)
+				}
+				defer func() {
+					if err := templateFile.Close(); err != nil {
+						slog.Error("Failed to close template file", "path", templateFilePath, "error", err)
+						os.Exit(1)
+					}
+				}()
+				templateReader = templateFile
+			}
+
+			// Validate stdin data format
 			stdinDataFormat, err := gunny.DataFormatFromString(stdinDataFormatString)
 			if err != nil {
 				slog.Error("Invalid argument(s)", "error", err)
 				os.Exit(1)
 			}
+
 			pipeline, err := gunny.NewPipeline(
-				gunny.WithMustacheTemplateFromReader(strings.NewReader(templateContent)),
-				gunny.WithDataFromReader(os.Stdin, stdinDataFormat),
+				gunny.WithMustacheTemplateFromReader(templateReader),
+				gunny.WithDataFromStdin(stdinDataFormat),
 				gunny.WithDataFromNameValuePairs(namedDataValues),
 			)
 			if err != nil {
@@ -64,13 +100,14 @@ func newRootCmd(version string, commit string) *cobra.Command {
 		Example: `
     # Render the value "Michael" (named "name") through the given template.
     gunny -t 'Hello {{name}}!' -d name=Michael
-	
-	# Supply data via stdin (in JSON format, by default)
-	echo '{"name": "Michael"}' | gunny -t 'Hello {{name}}!'`,
+    
+    # Supply data via stdin (in JSON format, by default)
+    echo '{"name": "Michael"}' | gunny -t 'Hello {{name}}!'`,
 	}
 	cmd.PersistentFlags().BoolVar(&showVersion, "version", false, "show the program version and exit immediately")
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "increase output logging verbosity")
 	cmd.PersistentFlags().StringVarP(&templateContent, "template", "t", "", "template content")
+	cmd.PersistentFlags().StringVar(&templateFilePath, "template-file", "", "file from which to read template")
 	cmd.PersistentFlags().StringArrayVarP(&namedDataValues, "data", "d", []string{}, "specify named data values (name=value) to inject into the template")
 	cmd.PersistentFlags().StringVar(&stdinDataFormatString, "stdin-format", stdinDataFormatString, "when supplying data via stdin, the format in which to interpret it")
 	return cmd

--- a/pkg/gunny/pipeline.go
+++ b/pkg/gunny/pipeline.go
@@ -42,6 +42,23 @@ func WithDataFromNameValuePairs(nameValuePairStrings []string) newPipelineOption
 	}
 }
 
+// WithDataFromStdin is similar to [WithDataFromReader], but first checks
+// whether there is any data available to read from stdin. Otherwise results in
+// an empty data set.
+func WithDataFromStdin(format DataFormat) newPipelineOption {
+	return func(pipeline *Pipeline) error {
+		stat, err := os.Stdin.Stat()
+		if err != nil {
+			return err
+		}
+		if (stat.Mode() & os.ModeCharDevice) != 0 {
+			// Do nothing
+			return nil
+		}
+		return WithDataFromReader(os.Stdin, format)(pipeline)
+	}
+}
+
 // WithDataFromReader allows one to supply data to a Gunny pipeline from a
 // reader. The format must be specified.
 func WithDataFromReader(reader io.Reader, format DataFormat) newPipelineOption {


### PR DESCRIPTION
Allow the user to supply a template from a file with `--template-file`.

Only Mustache templates are still supported at this time.